### PR TITLE
Fix: Set correct working directory for serverless validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           retention-days: 7
 
       - name: Validate serverless configuration
+        working-directory: server-src
         run: |
           NODE_NO_WARNINGS=1 npx serverless print --stage dev > /dev/null
           echo "✅ Serverless configuration is valid"


### PR DESCRIPTION
## Summary
- Fixed serverless validation failure in CI by adding explicit working directory
- The serverless command was failing because it wasn't running from server-src directory where serverless.yml is located
- Added `working-directory: server-src` to the serverless validation step in CI workflow

## Root Cause Analysis
**Problem**: The `serverless print` command was failing in CI with exit code 1, but working perfectly locally.

**Investigation**: 
- Local test from repo root: `NODE_NO_WARNINGS=1 npx serverless print --stage dev` → **FAILS** (exit code 1)
- Local test from server-src: `NODE_NO_WARNINGS=1 npx serverless print --stage dev` → **WORKS** (exit code 0)

**Error Message**: "This command can only be run in a Serverless service directory. Make sure to reference a valid config file in the current working directory"

**Cause**: While the backend-tests job has `defaults.run.working-directory: server-src`, the serverless validation step was somehow not inheriting this setting properly.

## Solution
Added explicit `working-directory: server-src` to the serverless validation step:

```yaml
- name: Validate serverless configuration
  working-directory: server-src  # ← This line was added
  run: |
    NODE_NO_WARNINGS=1 npx serverless print --stage dev > /dev/null
    echo "✅ Serverless configuration is valid"
```

## Test Plan
- [x] Verified serverless command fails from repo root locally
- [x] Verified serverless command works from server-src locally
- [x] Applied minimal targeted fix with explicit working directory
- [x] Preserved all existing CI functionality
- [ ] Verify CI pipeline passes with this fix

## Expected Results
- ✅ Security Audit: PASSED (preserved)
- ✅ Smoke Test: PASSED (preserved)  
- ✅ Frontend Tests: PASSED (preserved)
- ✅ Backend Tests: PASSED (including serverless validation)
- ✅ Test Results Summary: "All tests passed\! Ready for deployment"

🤖 Generated with [Claude Code](https://claude.ai/code)