### PR TITLE
fix: prevent AuthInterceptor from auto-logout on My Patches 401 errors

### DIFF
--- a/src/app/helpers/auth.interceptor.ts
+++ b/src/app/helpers/auth.interceptor.ts
@@ -34,6 +34,10 @@ export class AuthInterceptor implements HttpInterceptor {
       catchError(error => {
         if (error instanceof HttpErrorResponse) {
           if (error.status === 401 && !this.isRefreshRequest(req)) {
+            // Don't auto-logout for My Patches endpoint - let component handle gracefully
+            if (this.isMyPatchesRequest(req)) {
+              return throwError(() => error);
+            }
             return this.handle401Error(authReq, next);
           }
         }
@@ -50,6 +54,10 @@ export class AuthInterceptor implements HttpInterceptor {
 
   private isRefreshRequest(request: HttpRequest<any>): boolean {
     return request.url.includes('/api/auth/refresh');
+  }
+
+  private isMyPatchesRequest(request: HttpRequest<any>): boolean {
+    return request.url.includes('/api/patches/my');
   }
 
   private handle401Error(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {


### PR DESCRIPTION
## Summary
- Fixed the issue where My Patches page was logging users out and redirecting to login
- Modified AuthInterceptor to skip auto-logout behavior for My Patches API calls
- Allows My Patches component to gracefully handle unauthenticated state

## Problem
When users visited My Patches page:
1. Page loaded successfully (AuthGuard was removed)
2. Component called `/api/patches/my` API
3. API returned 401 (user not authenticated)
4. **AuthInterceptor automatically called `logout()` and redirected to login**
5. User was confused by unexpected logout behavior

## Root Cause
The `AuthInterceptor.handle401Error()` method was designed to logout users on any 401 error, but this prevented components from handling authentication gracefully.

## Solution
- **Added exception for My Patches API**: `isMyPatchesRequest()` method
- **Skip auto-logout**: When `/api/patches/my` returns 401, let component handle it
- **Preserve existing behavior**: Other endpoints still auto-logout on 401 (unchanged)

## Technical Details
```typescript
// New logic in AuthInterceptor
if (error.status === 401 && !this.isRefreshRequest(req)) {
  // Don't auto-logout for My Patches endpoint - let component handle gracefully
  if (this.isMyPatchesRequest(req)) {
    return throwError(() => error);
  }
  return this.handle401Error(authReq, next);
}
```

## User Experience Flow
- **Before**: Visit My Patches → API 401 → Auto logout → Redirect to login → Confusion
- **After**: Visit My Patches → API 401 → Component shows "Please log in to view your patches" → Clear UX

## Testing
- ✅ Build successful
- ✅ Tests passing: 44/44 (100% success rate)  
- ✅ Existing auth behavior preserved for other endpoints
- ✅ My Patches component can now handle unauthenticated users gracefully

This completes the My Patches UX improvement by preventing unwanted logouts while maintaining security.

🤖 Generated with [Claude Code](https://claude.ai/code)